### PR TITLE
Fix: Enabled word-splitting in scripts

### DIFF
--- a/dwall.sh
+++ b/dwall.sh
@@ -8,65 +8,87 @@
 set -o shwordsplit 2>/dev/null
 
 case "$OSTYPE" in
-	linux*) DIR="/usr/share/dynamic-wallpaper" ;;
-	*) DIR="/usr/share/dynamic-wallpaper" ;;
+	linux*)
+		DIR="/usr/share/dynamic-wallpaper"
+		;;
+	*)
+		DIR="/usr/share/dynamic-wallpaper"
+		;;
 esac
 
 case "$OSTYPE" in
-	linux*) TIME="$(date +%k)" ;;
-	*) TIME="$(date +%k)" ;;
+	linux*)
+		TIME="$(date +%k)"
+		;;
+	*)
+		TIME="$(date +%k)"
+		;;
 esac
 
 ## For XFCE
 if [ "$OSTYPE" == "linux"* ]; then
-    SCREEN="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $1}' | tr -d \:)"
-    MONITOR="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $2}' | tr -d \*+)"
+	SCREEN="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $1}' | tr -d \:)"
+	MONITOR="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $2}' | tr -d \*+)"
 fi
 
 case "$OSTYPE" in
-	linux*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image";
-	elif [[ "$DESKTOP_SESSION" =~ ^(MATE|Mate|mate)$ ]]; then SETTER="gsettings set org.mate.background picture-filename";
-	elif [[ "$DESKTOP_SESSION" =~ ^(Xfce Session|xfce session|XFCE|xfce|Xubuntu|xubuntu)$ ]]; then SETTER="xfconf-query --channel xfce4-desktop --property /backdrop/screen$SCREEN/monitor$MONITOR/workspace0/last-image --set";
-	elif [[ "$DESKTOP_SESSION" =~ ^(LXDE|Lxde|lxde)$ ]]; then SETTER="pcmanfm --set-wallpaper";
-	elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then SETTER="gsettings set org.gnome.desktop.background picture-uri";
-	else SETTER="feh --bg-scale"; fi ;;
-	*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image";
-	elif [[ "$DESKTOP_SESSION" =~ ^(MATE|Mate|mate)$ ]]; then SETTER="gsettings set org.mate.background picture-filename";
-	elif [[ "$DESKTOP_SESSION" =~ ^(Xfce Session|xfce session|XFCE|xfce|Xubuntu|xubuntu)$ ]]; then SETTER="xfconf-query --channel xfce4-desktop --property /backdrop/screen$SCREEN/monitor$MONITOR/workspace0/last-image --set";
-	elif [[ "$DESKTOP_SESSION" =~ ^(LXDE|Lxde|lxde)$ ]]; then SETTER="pcmanfm --set-wallpaper";
-	elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then SETTER="gsettings set org.gnome.desktop.background picture-uri";
-	else SETTER="feh --bg-scale"; fi ;;
+	linux*)
+		if [ -n "$SWAYSOCK" ]; then
+			SETTER="eval ogurictl output '*' --image";
+		elif [[ "$DESKTOP_SESSION" =~ ^(MATE|Mate|mate)$ ]]; then
+			SETTER="gsettings set org.mate.background picture-filename";
+		elif [[ "$DESKTOP_SESSION" =~ ^(Xfce Session|xfce session|XFCE|xfce|Xubuntu|xubuntu)$ ]]; then
+			SETTER="xfconf-query --channel xfce4-desktop --property /backdrop/screen$SCREEN/monitor$MONITOR/workspace0/last-image --set";
+		elif [[ "$DESKTOP_SESSION" =~ ^(LXDE|Lxde|lxde)$ ]]; then
+			SETTER="pcmanfm --set-wallpaper";
+		elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then
+			SETTER="gsettings set org.gnome.desktop.background picture-uri";
+		else
+			SETTER="feh --bg-scale"
+		fi
+		;;
+	*)
+		if [ -n "$SWAYSOCK" ]; then
+			SETTER="eval ogurictl output '*' --image";
+		elif [[ "$DESKTOP_SESSION" =~ ^(MATE|Mate|mate)$ ]]; then
+			SETTER="gsettings set org.mate.background picture-filename";
+		elif [[ "$DESKTOP_SESSION" =~ ^(Xfce Session|xfce session|XFCE|xfce|Xubuntu|xubuntu)$ ]]; then
+			SETTER="xfconf-query --channel xfce4-desktop --property /backdrop/screen$SCREEN/monitor$MONITOR/workspace0/last-image --set";
+		elif [[ "$DESKTOP_SESSION" =~ ^(LXDE|Lxde|lxde)$ ]]; then
+			SETTER="pcmanfm --set-wallpaper";
+		elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then
+			SETTER="gsettings set org.gnome.desktop.background picture-uri";
+		else
+			SETTER="feh --bg-scale"
+		fi
+		;;
 esac
 
 STYLE=
 
 set_wallpaper() {
-  image="$DIR/images/$STYLE/$1"
-  if [ $FORMAT ]; then
-    $SETTER "$image.$FORMAT"
-    return;
-  fi
-  errormessage=$($SETTER "$image.png" 2>&1)
-  if [ ! -z "$errormessage" ]; then
-    errormessage=$($SETTER "$image.jpg" 2>&1)
-    if [ ! -z "$errormessage" ]; then
-      echo "Image $TIME.jpg/.png Not Available, Exiting..."; exit 1;
-    fi
-    FORMAT="jpg"
-  else
-    FORMAT="png"
-  fi
+	image="$DIR/images/$STYLE/$1"
+	if [ -f "$image.png" ]; then
+		FORMAT="png"
+	elif [ -f "$image.jpg" ]; then
+		FORMAT="jpg"
+	else
+		echo "Image $TIME.jpg/.png Not Available, Exiting..."; exit 1;
+	fi
+	if [ $FORMAT ]; then
+		$SETTER "$image.$FORMAT"
+	fi
 }
 
 main() {
-  num=$(echo "scale=2; $TIME/24*$NUMBER" | bc | awk '{print int($1+0.5)}')
-  set_wallpaper $num && sleep 60
-  echo "Running..."
+	num=$(echo "scale=2; $TIME/24*$NUMBER" | bc | awk '{print int($1+0.5)}')
+	set_wallpaper $num && sleep 60
+	echo "Running..."
 }
 
 usage() {
-available_styles=($(ls $DIR/images))
-echo -n "
+	available_styles=($(ls $DIR/images))
+	echo -n "
 Dynamic Wallpaper V1.0 - (C) Aditya Shakya - @adi1090x
 Simple script to show a dynamic wallpaper based on time.
 
@@ -78,39 +100,41 @@ Example: dwall -s=firewatch
 Styles folder: $DIR/images/
 
 "
-printf "Available Styles: "
-printf -- '%s  ' "${available_styles[@]}"
-printf -- '\n\n'
+	printf "Available Styles: "
+	printf -- '%s	' "${available_styles[@]}"
+	printf -- '\n\n'
 }
 
 init() {
-    while true; do
-        main && exec $DIR/dwall.sh -s=$STYLE
-    done
+	while true; do
+		main && exec $DIR/dwall.sh -s=$STYLE
+	done
 }
 
-for i in "$@"
-do
-case $i in
-    -s=*|--style=*)
-    STYLE="${i#*=}"
-    ;;
-    -h|--help)
-    usage
-    ;;
-    *)
-    echo -n "Unknown option: $i"
-    usage
-    ;;
-esac
+for i in "$@"; do
+	case $i in
+		-s=*|--style=*)
+			STYLE="${i#*=}"
+			;;
+		-h|--help)
+			usage
+			exit
+			;;
+		*)
+			echo -n "Unknown option: $i"
+			usage
+			exit
+		;;
+	esac
 done
 
 if [ -z "$NUMBER" ]; then
-    NUMBER=$(ls $DIR/images/$STYLE -1 | wc -l)
+	NUMBER=$(ls $DIR/images/$STYLE -1 | wc -l)
 fi
 
 if [ "$STYLE" ]; then
-    init
+	init
 else
-    usage
+	usage
 fi
+

--- a/dwall.sh
+++ b/dwall.sh
@@ -124,7 +124,7 @@ for i in "$@"; do
 			echo -n "Unknown option: $i"
 			usage
 			exit
-		;;
+			;;
 	esac
 done
 

--- a/dwall.sh
+++ b/dwall.sh
@@ -5,6 +5,8 @@
 ## Github : @adi1090x
 ## Reddit : @adi1090x
 
+set -o shwordsplit 2>/dev/null
+
 case "$OSTYPE" in
 	linux*) DIR="/usr/share/dynamic-wallpaper" ;;
 	*) DIR="/usr/share/dynamic-wallpaper" ;;

--- a/install.sh
+++ b/install.sh
@@ -13,18 +13,30 @@ Y='\033[1;33m'
 # Path
 DIR="$(pwd)"
 case "$OSTYPE" in
-       linux*) DES="/usr/share" ;; 
-       *) DES="/usr/share" ;;
+	linux*)
+		DES="/usr/share"
+		;; 
+	*)
+		DES="/usr/share"
+		;;
 esac
 
 case "$OSTYPE" in
-       linux*) BIN="/usr/bin" ;; 
-       *) BIN="/usr/bin" ;;
+	linux*)
+		BIN="/usr/bin"
+		;; 
+	*)
+		BIN="/usr/bin"
+		;;
 esac
 
 case "$OSTYPE" in
-       linux*) SUDO="sudo" ;; 
-       *) SUDO="sudo" ;;
+	linux*)
+		SUDO="sudo"
+		;; 
+	*)
+		SUDO="sudo"
+		;;
 esac
 
 echo
@@ -32,13 +44,13 @@ echo -e $Y" [*] Installing... "$C
 echo
 # delete old dir if already exist
 if [[ -d $DES/dynamic-wallpaper ]]; then
-    $SUDO rm -rf $DES/dynamic-wallpaper    
+	$SUDO rm -rf $DES/dynamic-wallpaper    
 fi
 $SUDO mkdir -p $DES/dynamic-wallpaper && $SUDO cp -r $DIR/images $DES/dynamic-wallpaper && $SUDO cp -r $DIR/dwall.sh $DES/dynamic-wallpaper
 $SUDO chmod +x $DES/dynamic-wallpaper/dwall.sh
 # delete executable if already exist
 if [[ -f $BIN/dwall ]]; then
-    $SUDO rm $BIN/dwall    
+	$SUDO rm $BIN/dwall    
 fi
 $SUDO ln -s $DES/dynamic-wallpaper/dwall.sh $BIN/dwall
 echo

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ DIR="$(pwd)"
 case "$OSTYPE" in
 	linux*)
 		DES="/usr/share"
-		;; 
+		;;
 	*)
 		DES="/usr/share"
 		;;
@@ -24,7 +24,7 @@ esac
 case "$OSTYPE" in
 	linux*)
 		BIN="/usr/bin"
-		;; 
+		;;
 	*)
 		BIN="/usr/bin"
 		;;
@@ -33,7 +33,7 @@ esac
 case "$OSTYPE" in
 	linux*)
 		SUDO="sudo"
-		;; 
+		;;
 	*)
 		SUDO="sudo"
 		;;
@@ -44,13 +44,13 @@ echo -e $Y" [*] Installing... "$C
 echo
 # delete old dir if already exist
 if [[ -d $DES/dynamic-wallpaper ]]; then
-	$SUDO rm -rf $DES/dynamic-wallpaper    
+	$SUDO rm -rf $DES/dynamic-wallpaper
 fi
 $SUDO mkdir -p $DES/dynamic-wallpaper && $SUDO cp -r $DIR/images $DES/dynamic-wallpaper && $SUDO cp -r $DIR/dwall.sh $DES/dynamic-wallpaper
 $SUDO chmod +x $DES/dynamic-wallpaper/dwall.sh
 # delete executable if already exist
 if [[ -f $BIN/dwall ]]; then
-	$SUDO rm $BIN/dwall    
+	$SUDO rm $BIN/dwall
 fi
 $SUDO ln -s $DES/dynamic-wallpaper/dwall.sh $BIN/dwall
 echo

--- a/test.sh
+++ b/test.sh
@@ -5,6 +5,8 @@
 ## Github : @adi1090x
 ## Reddit : @adi1090x
 
+set -o shwordsplit 2>/dev/null
+
 case "$OSTYPE" in
 	linux*) DIR="$(pwd)" ;;
 	*) DIR="$(pwd)" ;;

--- a/test.sh
+++ b/test.sh
@@ -8,65 +8,87 @@
 set -o shwordsplit 2>/dev/null
 
 case "$OSTYPE" in
-	linux*) DIR="$(pwd)" ;;
-	*) DIR="$(pwd)" ;;
+	linux*)
+		DIR="$(pwd)"
+		;;
+	*)
+		DIR="$(pwd)"
+		;;
 esac
 
 case "$OSTYPE" in
-	linux*) TIME="$(date +%k)" ;;
-	*) TIME="$(date +%k)" ;;
+	linux*)
+		TIME="$(date +%k)"
+		;;
+	*)
+		TIME="$(date +%k)"
+		;;
 esac
 
 ## For XFCE
 if [ "$OSTYPE" == "linux"* ]; then
-    SCREEN="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $1}' | tr -d \:)"
-    MONITOR="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $2}' | tr -d \*+)"
+	SCREEN="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $1}' | tr -d \:)"
+	MONITOR="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $2}' | tr -d \*+)"
 fi
 
 case "$OSTYPE" in
-	linux*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image";
-	elif [[ "$DESKTOP_SESSION" =~ ^(MATE|Mate|mate)$ ]]; then SETTER="gsettings set org.mate.background picture-filename";
-	elif [[ "$DESKTOP_SESSION" =~ ^(Xfce Session|xfce session|XFCE|xfce|Xubuntu|xubuntu)$ ]]; then SETTER="xfconf-query --channel xfce4-desktop --property /backdrop/screen$SCREEN/monitor$MONITOR/workspace0/last-image --set";
-	elif [[ "$DESKTOP_SESSION" =~ ^(LXDE|Lxde|lxde)$ ]]; then SETTER="pcmanfm --set-wallpaper";
-	elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then SETTER="gsettings set org.gnome.desktop.background picture-uri";
-	else SETTER="feh --bg-scale"; fi ;;
-	*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image";
-	elif [[ "$DESKTOP_SESSION" =~ ^(MATE|Mate|mate)$ ]]; then SETTER="gsettings set org.mate.background picture-filename";
-	elif [[ "$DESKTOP_SESSION" =~ ^(Xfce Session|xfce session|XFCE|xfce|Xubuntu|xubuntu)$ ]]; then SETTER="xfconf-query --channel xfce4-desktop --property /backdrop/screen$SCREEN/monitor$MONITOR/workspace0/last-image --set";
-	elif [[ "$DESKTOP_SESSION" =~ ^(LXDE|Lxde|lxde)$ ]]; then SETTER="pcmanfm --set-wallpaper";
-	elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then SETTER="gsettings set org.gnome.desktop.background picture-uri";
-	else SETTER="feh --bg-scale"; fi ;;
+	linux*)
+		if [ -n "$SWAYSOCK" ]; then
+			SETTER="eval ogurictl output '*' --image";
+		elif [[ "$DESKTOP_SESSION" =~ ^(MATE|Mate|mate)$ ]]; then
+			SETTER="gsettings set org.mate.background picture-filename";
+		elif [[ "$DESKTOP_SESSION" =~ ^(Xfce Session|xfce session|XFCE|xfce|Xubuntu|xubuntu)$ ]]; then
+			SETTER="xfconf-query --channel xfce4-desktop --property /backdrop/screen$SCREEN/monitor$MONITOR/workspace0/last-image --set";
+		elif [[ "$DESKTOP_SESSION" =~ ^(LXDE|Lxde|lxde)$ ]]; then
+			SETTER="pcmanfm --set-wallpaper";
+		elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then
+			SETTER="gsettings set org.gnome.desktop.background picture-uri";
+		else
+			SETTER="feh --bg-scale"
+		fi
+		;;
+	*)
+		if [ -n "$SWAYSOCK" ]; then
+			SETTER="eval ogurictl output '*' --image";
+		elif [[ "$DESKTOP_SESSION" =~ ^(MATE|Mate|mate)$ ]]; then
+			SETTER="gsettings set org.mate.background picture-filename";
+		elif [[ "$DESKTOP_SESSION" =~ ^(Xfce Session|xfce session|XFCE|xfce|Xubuntu|xubuntu)$ ]]; then
+			SETTER="xfconf-query --channel xfce4-desktop --property /backdrop/screen$SCREEN/monitor$MONITOR/workspace0/last-image --set";
+		elif [[ "$DESKTOP_SESSION" =~ ^(LXDE|Lxde|lxde)$ ]]; then
+			SETTER="pcmanfm --set-wallpaper";
+		elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then
+			SETTER="gsettings set org.gnome.desktop.background picture-uri";
+		else
+			SETTER="feh --bg-scale"
+		fi
+		;;
 esac
 
 STYLE=
 
 set_wallpaper() {
-  image="$DIR/images/$STYLE/$1"
-  if [ $FORMAT ]; then
-    $SETTER "$image.$FORMAT"
-    return;
-  fi
-  errormessage=$($SETTER "$image.png" 2>&1)
-  if [ ! -z "$errormessage" ]; then
-    errormessage=$($SETTER "$image.jpg" 2>&1)
-    if [ ! -z "$errormessage" ]; then
-      echo "Image $TIME.jpg/.png Not Available, Exiting..."; exit 1;
-    fi
-    FORMAT="jpg"
-  else
-    FORMAT="png"
-  fi
+	image="$DIR/images/$STYLE/$1"
+	if [ -f "$image.png" ]; then
+		FORMAT="png"
+	elif [ -f "$image.jpg" ]; then
+		FORMAT="jpg"
+	else
+		echo "Image $TIME.jpg/.png Not Available, Exiting..."; exit 1;
+	fi
+	if [ $FORMAT ]; then
+		$SETTER "$image.$FORMAT"
+	fi
 }
 
 main() {
-  num=$(echo "scale=2; $TIME/24*$NUMBER" | bc | awk '{print int($1+0.5)}')
-  set_wallpaper $num && sleep 60
-  echo "Running..."
+	num=$(echo "scale=2; $TIME/24*$NUMBER" | bc | awk '{print int($1+0.5)}')
+	set_wallpaper $num && sleep 60
+	echo "Running..."
 }
 
 usage() {
-available_styles=($(ls $DIR/images))
-echo -n "
+	available_styles=($(ls $DIR/images))
+	echo -n "
 Dynamic Wallpaper V1.0 - (C) Aditya Shakya - @adi1090x
 Simple script to show a dynamic wallpaper based on time.
 
@@ -78,39 +100,41 @@ Example: dwall -s=firewatch
 Styles folder: $DIR/images/
 
 "
-printf "Available Styles: "
-printf -- '%s  ' "${available_styles[@]}"
-printf -- '\n\n'
+	printf "Available Styles: "
+	printf -- '%s	' "${available_styles[@]}"
+	printf -- '\n\n'
 }
 
 init() {
-    while true; do
-        main && exec $DIR/test.sh -s=$STYLE
-    done
+	while true; do
+		main && exec $DIR/test.sh -s=$STYLE
+	done
 }
 
-for i in "$@"
-do
-case $i in
-    -s=*|--style=*)
-    STYLE="${i#*=}"
-    ;;
-    -h|--help)
-    usage
-    ;;
-    *)
-    echo -n "Unknown option: $i"
-    usage
-    ;;
-esac
+for i in "$@"; do
+	case $i in
+		-s=*|--style=*)
+			STYLE="${i#*=}"
+			;;
+		-h|--help)
+			usage
+			exit
+			;;
+		*)
+			echo -n "Unknown option: $i"
+			usage
+			exit
+			;;
+	esac
 done
 
 if [ -z "$NUMBER" ]; then
-    NUMBER=$(ls $DIR/images/$STYLE -1 | wc -l)
+	NUMBER=$(ls $DIR/images/$STYLE -1 | wc -l)
 fi
 
 if [ "$STYLE" ]; then
-    init
+	init
 else
-    usage
+	usage
 fi
+

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,18 +13,30 @@ Y='\033[1;33m'
 # Path
 DIR="$(pwd)"
 case "$OSTYPE" in
-       linux*) DES="/usr/share" ;; 
-       *) DES="/usr/share" ;;
+	linux*)
+		DES="/usr/share"
+		;;
+	*)
+		DES="/usr/share"
+		;;
 esac
 
 case "$OSTYPE" in
-       linux*) BIN="/usr/bin" ;; 
-       *) BIN="/usr/bin" ;;
+	linux*)
+		BIN="/usr/bin"
+		;;
+	*)
+		BIN="/usr/bin"
+		;;
 esac
 
 case "$OSTYPE" in
-       linux*) SUDO="sudo" ;; 
-       *) SUDO="sudo" ;;
+	linux*)
+		SUDO="sudo"
+		;;
+	*)
+		SUDO="sudo"
+		;;
 esac
 
 echo
@@ -32,11 +44,11 @@ echo -e $Y" [*] Uninstalling... "$C
 echo
 # delete old dir if it exists
 if [[ -d $DES/dynamic-wallpaper ]]; then
-    $SUDO rm -rf $DES/dynamic-wallpaper    
+    $SUDO rm -rf $DES/dynamic-wallpaper
 fi
 # delete executable if it exists
 if [[ -L $BIN/dwall ]]; then
-    $SUDO rm $BIN/dwall    
+    $SUDO rm $BIN/dwall
 fi
 echo
 echo -e $Y" [*] Uninstalled."$C


### PR DESCRIPTION
Allows the script to run in shells such as Zsh which do not have word splitting enabled by default.

As seen in [Issue #7](https://github.com/adi1090x/dynamic-wallpaper/issues/7)