### PR TITLE
Reset bolding and color at end of output

### DIFF
--- a/dwall.sh
+++ b/dwall.sh
@@ -139,6 +139,7 @@ usage() {
 init() {
 	if [ "$RUN_ONCE" == "true" ]; then
 		main;
+		reset_color;
 		exit 0;
     fi
     while true; do
@@ -151,6 +152,11 @@ is_valid_style() {
     for i in "${available_styles[@]}"; do
         [ "$i" == "$1" ] && STYLE=$(echo "$1")
     done
+}
+
+reset_color() {
+	tput sgr0 # reset attributes
+	tput op # reset color
 }
 
 is_valid_style "$1"
@@ -166,14 +172,17 @@ while getopts ":s:o:h" opt; do
 		;;
     h )
 		usage
+		reset_color
 		exit 0
 		;;
     \?)
 		echo -e $R"Unknown option,$G run dwall -h"
+		reset_color
 		exit 1
 		;;
     : )
 		echo -e $R"Invalid:$G -$OPTARG$R requires an argument."
+		reset_color
 		exit 1
 		;;
   esac
@@ -183,4 +192,5 @@ if [ "$STYLE" ]; then
     init
 else
 	usage
+	reset_color
 fi

--- a/test.sh
+++ b/test.sh
@@ -103,7 +103,7 @@ set_wallpaper() {
   elif [ -f "$image.jpg" ]; then
 		FORMAT="jpg"
   else
-		echo -e $R"Invalid theme/style, Try again."; exit 1;
+		echo -e $R"Invalid theme/style, Try again."; reset_color; exit 1;
   fi
   if [ $FORMAT ]; then
 		$SETTER "$image.$FORMAT"
@@ -139,6 +139,7 @@ usage() {
 init() {
 	if [ "$RUN_ONCE" == "true" ]; then
 		main;
+		reset_color;
 		exit 0;
     fi
     while true; do
@@ -151,6 +152,11 @@ is_valid_style() {
     for i in "${available_styles[@]}"; do
         [ "$i" == "$1" ] && STYLE=$(echo "$1")
     done
+}
+
+reset_color() {
+	tput sgr0 # reset attributes
+	tput op # reset color
 }
 
 is_valid_style "$1"
@@ -166,14 +172,17 @@ while getopts ":s:o:h" opt; do
 		;;
     h )
 		usage
+		reset_color
 		exit 0
 		;;
     \?)
 		echo -e $R"Unknown option,$G run ./test.sh -h"
+		reset_color
 		exit 1
 		;;
     : )
 		echo -e $R"Invalid:$G -$OPTARG$R requires an argument."
+		reset_color
 		exit 1
 		;;
   esac
@@ -183,4 +192,5 @@ if [ "$STYLE" ]; then
     init
 else
 	usage
+	reset_color
 fi


### PR DESCRIPTION
This fixes #12 by resetting colour and bolding at the end of output. This is shown to be working here:

![fixed bolding](https://i.imgur.com/Jky8fMk.png)

We can see that the prompt is formatted correctly compared to the screenshots in #12.