### PR TITLE
KDE with different WM

### DIFF
--- a/dwall.sh
+++ b/dwall.sh
@@ -19,17 +19,21 @@ set -o shwordsplit 2>/dev/null
 
 # set wallpaper in kde
 setkde() {
-qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "
-    var allDesktops = desktops();
-    print (allDesktops);
-    for (i=0;i<allDesktops.length;i++) {
-        d = allDesktops[i];
-        d.wallpaperPlugin = 'org.kde.image';
-        d.currentConfigGroup = Array('Wallpaper',
-                                    'org.kde.image',
-                                    'General');
-        d.writeConfig('Image', 'file://"$1"')
-    }"
+if [[ "$KDEWM" =~ ^/usr/bin/kwin ]]; then
+    qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "
+	var allDesktops = desktops();
+	print (allDesktops);
+	for (i=0;i<allDesktops.length;i++) {
+	    d = allDesktops[i];
+	    d.wallpaperPlugin = 'org.kde.image';
+	    d.currentConfigGroup = Array('Wallpaper',
+					'org.kde.image',
+					'General');
+	    d.writeConfig('Image', 'file://"$1"')
+	}"
+else
+    feh --bg-scale $1;
+fi
 }
 
 case "$OSTYPE" in


### PR DESCRIPTION
Hi!
I use KDE but I changed the WM to i3.
The problem is that dwall detects my setup as KDE and uses dbus while it shoud use feh.
I added a very simple WM detection using the `$KDEWM` variable to use feh when kwin is not used.
This is very basic but this solved my problem.