### PR TITLE
Support for Gnome on X11

### DIFF
--- a/dwall.sh
+++ b/dwall.sh
@@ -68,7 +68,7 @@ case "$OSTYPE" in
 				SETTER="pcmanfm --set-wallpaper";
             elif [[ "$DESKTOP_SESSION" =~ ^(/usr/share/xsessions/plasma|NEON|Neon|neon|PLASMA|Plasma|plasma|KDE|Kde|kde)$ ]]; then 
 				SETTER=setkde;
-			elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then 
+			elif [[ "$DESKTOP_SESSION" =~ ^(PANTHEON|Pantheon|pantheon|GNOME|Gnome|gnome|gnome-xorg|UBUNTU|Ubuntu|ubuntu|DEEPIN|Deepin|deepin|POP|Pop|pop)$ ]]; then 
 				SETTER="gsettings set org.gnome.desktop.background picture-uri";
 			else 
 				SETTER="feh --bg-scale"; 


### PR DESCRIPTION
Gnome-org sessions are not supported (DESKTOP_SESSION=gnome-xorg).

I have only tested this on Gnome 3.36.2.

Resolves issue https://github.com/adi1090x/dynamic-wallpaper/issues/16