### PR TITLE
Add option to copy wallpaper to a file instead of setting the wallpaper

### DIFF
--- a/dwall.sh
+++ b/dwall.sh
@@ -165,7 +165,18 @@ pywal_set() {
 ## Put wallpaper in $OUTPUT
 file_set() {
 	get_img "$1"
-	cp "$image.$FORMAT" "$OUTPUT"
+	if [[ -n $(echo "$OUTPUT" | grep -o "^[/~]") ]]
+	then
+		DIR=$(dirname $OUTPUT)
+		if [[ -d $DIR ]]
+		then
+			cp "$image.$FORMAT" "$OUTPUT"
+		else
+			echo "[!] Directory $DIR does not exist, exiting..."
+		fi
+	else
+		echo "[!] Output must be an absolute path, $OUTPUT isn't, exiting..."
+	fi
 }
 
 ## Wallpaper Setter

--- a/dwall.sh
+++ b/dwall.sh
@@ -69,6 +69,7 @@ usage() {
 		Options:
 		   -h	Show this help message
 		   -p	Use pywal to set wallpaper
+		   -o	Copy wallpaper to this file
 		   -s	Name of the style to apply
 		   
 	EOF
@@ -161,6 +162,12 @@ pywal_set() {
 	fi
 }
 
+## Put wallpaper in $OUTPUT
+file_set() {
+	get_img "$1"
+	cp "$image.$FORMAT" "$OUTPUT"
+}
+
 ## Wallpaper Setter
 set_wallpaper() {
 	cfile="$HOME/.cache/dwall_current"
@@ -206,16 +213,21 @@ main() {
 	# set wallpaper accordingly
 	if [[ -n "$PYWAL" ]]; then
 		{ pywal_set "$num"; reset_color; exit 0; }
+	elif [[ -n "$OUTPUT" ]]; then
+		{ file_set "$num"; reset_color; exit 0; }
 	else
 		{ set_wallpaper "$num"; reset_color; exit 0; }
 	fi
 }
 
 ## Get Options
-while getopts ":s:hp" opt; do
+while getopts ":s:o:hp" opt; do
 	case ${opt} in
 		p)
 			PYWAL=true
+			;;
+		o)
+			OUTPUT=$OPTARG
 			;;
 		s)
 			STYLE=$OPTARG

--- a/dwall.sh
+++ b/dwall.sh
@@ -64,7 +64,7 @@ usage() {
 		Dwall V2.0   : Set wallpapers according to current time.
 		Developed By : Aditya Shakya (@adi1090x)
 			
-		Usage : `basename $0` [-h] [-p] [-s style]
+		Usage : `basename $0` [-h] [-p] [-o output] [-s style]
 
 		Options:
 		   -h	Show this help message
@@ -81,8 +81,9 @@ usage() {
 
     cat <<- EOF
 		Examples: 
-		`basename $0` -s beach        Set wallpaper from 'beach' style
-		`basename $0` -p -s sahara    Set wallpaper from 'sahara' style using pywal
+		`basename $0` -s beach        			Set wallpaper from 'beach' style
+		`basename $0` -p -s sahara    			Set wallpaper from 'sahara' style using pywal
+		`basename $0` -o ~/wallpaper -s sahara	Copy current sahara wallpaper to ~/wallpaper, you have to change the wallpaper with a separate script
 		
 	EOF
 }


### PR DESCRIPTION
That way we can use other pywal arguments, use pywal alternatives like [lule](https://github.com/warpwm/lule_bash), use a different wallpaper setter, or do whatever else you may want to do with the wallpaper. It makes more sense to atleast have the option to not set the wallpaper, the script is a lot more flexible like this.